### PR TITLE
Bump compose-compiler, kotlin, navigation, material3, lifecycle-runtime, activity-compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion compose_compiler_version
     }
     packagingOptions {
         resources {
@@ -49,19 +49,23 @@ android {
 }
 
 dependencies {
-    def nav_version = "2.4.2"
+    def nav_version = "2.5.0"
     def hilt_version = "2.42"
     def gson_version = "2.9.0"
+    def core_version = "1.8.0"
+    def material3_version = "1.0.0-alpha14"
+    def lifecycle_version = "2.5.0"
+    def activity_version = "1.5.0"
 
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation "androidx.core:core-ktx:$core_version"
     implementation "androidx.compose.ui:ui:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.0.0-alpha13'
+    implementation "androidx.compose.material3:material3:$material3_version"
     implementation "androidx.navigation:navigation-compose:$nav_version"
-    implementation "androidx.compose.foundation:foundation:1.2.0-rc01"
+    implementation "androidx.compose.foundation:foundation:$compose_version"
 
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+    implementation "androidx.activity:activity-compose:$activity_version"
 
     // Hilt
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     ext {
-        compose_version = '1.2.0-rc01'
+        // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
+        compose_compiler_version = '1.3.0-rc01'
+        compose_version = '1.2.0'
         hilt_version = '2.42'
     }
 
@@ -11,7 +13,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '7.2.0' apply false
     id 'com.android.library' version '7.2.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Bump compose compiler to 1.3.0-rc01
Bump kotlin to 1.7.10
Bump navigation to 2.5.0
Bump material3 to 1.0.0-alpha14.
Bump lifecycle-runtime to 2.5.0
Bump activity-compose to 1.5.0