### PR TITLE
Bump compileSdk, compose-compiler, kotlin, and jetpack libraries

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
-  </component>
-</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,11 +31,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.waseefakhtar.doseapp"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -52,17 +52,20 @@ android {
 }
 
 dependencies {
-    def compose_ui_version = "1.4.0-rc01"
-    def nav_version = "2.5.3"
-    def hilt_version = "2.45"
+    // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
+    // Also check Jetpack libraries update to go along with it: https://developer.android.com/jetpack/androidx/versions/all-channel
+
+    def compose_ui_version = "1.6.0-alpha04"
+    def nav_version = "2.7.1"
+    def hilt_version = "2.47"
     def androidx_hilt_version = "1.0.0"
     def gson_version = "2.9.0"
-    def room_version = "2.5.0"
+    def room_version = "2.6.0-beta01"
     def okhttp_version = "4.10.0"
-    def core_version = "1.9.0"
-    def material3_version = "1.1.0-beta01"
-    def lifecycle_version = "2.6.0"
-    def activity_version = "1.6.1"
+    def core_version = "1.12.0-rc01"
+    def material3_version = "1.2.0-alpha06"
+    def lifecycle_version = "2.7.0-alpha01"
+    def activity_version = "1.8.0-alpha07"
     def firebase_version = "30.4.1"
 
     implementation "androidx.core:core-ktx:$core_version"

--- a/app/src/main/java/com/waseefakhtar/doseapp/DoseApp.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/DoseApp.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.consumedWindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -112,7 +112,7 @@ fun DoseApp() {
                         navController = navController,
                         modifier = Modifier
                             .padding(padding)
-                            .consumedWindowInsets(padding)
+                            .consumeWindowInsets(padding)
                     )
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
     id "org.jlleitschuh.gradle.ktlint" version "10.3.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     ext {
         // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
-        compose_compiler_version = '1.4.4'
+        // Also check Jetpack libraries update to go along with it: https://developer.android.com/jetpack/androidx/versions/all-channel
+        compose_compiler_version = '1.5.2'
         compose_version = '1.3.3'
-        hilt_version = '2.45'
+        hilt_version = '2.47'
         ktlint_version = '10.3.0'
         google_services_version = '4.3.13'
         firebase_crashlytics_version = '2.9.1'
@@ -24,7 +25,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.0.2' apply false
     id 'com.android.library' version '8.0.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
     id "org.jlleitschuh.gradle.ktlint" version "10.3.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 16 23:12:35 PKT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump compileSdk to 34
Bump compose-ui to 1.6.0-alpha04
Bump compose-compiler to 1.5.2
Bump kotlin to 1.9.0
Bump navigation to 2.7.1
Bump hilt to 2.47
Bump room to 2.6.0-beta01
Bump core to 1.12.0-rc01
Bump material3 to 1.2.0-alpha06
Bump lifecycle-runtime to 2.7.0-alpha01
Bump activity-compose to 1.8.0-alpha07