### PR TITLE
[issue-75] A big medication name hide "Take now" button from Home screen

### DIFF
--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/HomeScreen.kt
@@ -273,7 +273,13 @@ fun DailyMedications(navController: NavController, analyticsHelper: AnalyticsHel
                         )
                     }
                     is MedicationListItem.MedicationItem -> {
-                        MedicationCard(it.medication, viewModel, analyticsHelper)
+                        MedicationCard(
+                            it.medication,
+                            onTakeButtonClicked = { medication ->
+                                analyticsHelper.logEvent(AnalyticsEvents.TAKE_MEDICATION_CLICKED)
+                                viewModel.takeMedication(medication)
+                            }
+                        )
                     }
                 }
             }
@@ -285,72 +291,6 @@ sealed class MedicationListItem {
     data class OverviewItem(val medicationsToday: List<Medication>, val isMedicationListEmpty: Boolean) : MedicationListItem()
     data class MedicationItem(val medication: Medication) : MedicationListItem()
     data class HeaderItem(val headerText: String) : MedicationListItem()
-}
-
-@Composable
-fun MedicationCard(medication: Medication, viewModel: HomeViewModel, analyticsHelper: AnalyticsHelper) {
-
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        shape = RoundedCornerShape(30.dp),
-        colors = cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        )
-    ) {
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-
-            Column(
-                modifier = Modifier
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.Start
-            ) {
-                Text(
-                    text = medication.name,
-                    fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.titleLarge
-                )
-                Text(
-                    text = medication.timesOfDay.joinToString(", ")
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = getTimeRemaining(medication),
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.End
-            ) {
-
-                Button(
-                    onClick = {
-                        analyticsHelper.logEvent(AnalyticsEvents.TAKE_MEDICATION_CLICKED)
-                        viewModel.takeMedication(medication)
-                    },
-                    enabled = !medication.medicationTaken
-                ) {
-                    if (medication.medicationTaken) {
-                        Text(
-                            text = "Taken"
-                        )
-                    } else {
-                        Text(
-                            text = "Take now"
-                        )
-                    }
-                }
-            }
-        }
-    }
 }
 
 @OptIn(ExperimentalPermissionsApi::class)

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/MedicationCard.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/MedicationCard.kt
@@ -1,0 +1,121 @@
+package com.waseefakhtar.doseapp.feature.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.waseefakhtar.doseapp.domain.model.Medication
+import com.waseefakhtar.doseapp.util.getTimeRemaining
+import java.util.Date
+
+@Composable
+fun MedicationCard(
+    medication: Medication,
+    onTakeButtonClicked: (Medication) -> Unit
+) {
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        shape = RoundedCornerShape(30.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+    ) {
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            Column(
+                modifier = Modifier
+                    .weight(2f)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = medication.name,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Text(
+                    text = medication.timesOfDay.joinToString(", ")
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = getTimeRemaining(medication),
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Button(
+                modifier = Modifier.weight(1f).padding(end = 16.dp),
+                onClick = { onTakeButtonClicked(medication) },
+                enabled = !medication.medicationTaken
+            ) {
+                if (medication.medicationTaken) {
+                    Text(
+                        text = "Taken"
+                    )
+                } else {
+                    Text(
+                        text = "Take now"
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MedicationCardTakeNowPreview() {
+    MedicationCard(
+        Medication(
+            id = 123L,
+            name = "A big big name for a little medication I needs to take",
+            dosage = 1,
+            recurrence = "2",
+            endDate = Date(),
+            timesOfDay = listOf(),
+            medicationTaken = false,
+            date = Date(),
+        )
+    ) {
+
+    }
+}
+
+@Preview
+@Composable
+private fun MedicationCardTakenPreview() {
+    MedicationCard(
+        Medication(
+            id = 123L,
+            name = "A big big name for a little medication I needs to take",
+            dosage = 1,
+            recurrence = "2",
+            endDate = Date(),
+            timesOfDay = listOf(),
+            medicationTaken = true,
+            date = Date(),
+        )
+    ) {
+
+    }
+}


### PR DESCRIPTION
closes #75 

# Context

This pull request solve button gone when medication name is too long.

# Solution

To solve it problem was needed use `weight` modifier property to components respect spaces between them.

I moved MedicationCard to a new archive to isolate component and create previews to test UI easily.

I also removed ViewModel and Analytics dependency from MedicationCard to the component become more easy to test.

# Screenshots

![preview](https://github.com/waseefakhtar/dose-android/assets/24254062/30566cfe-ea9f-4b19-b966-7495c804c3bf)

https://github.com/waseefakhtar/dose-android/assets/24254062/aa3c7ce0-ecb9-403a-ad8c-2a964baf9892



