### PR TITLE
Bump AGP, Gradle, and other Jetpack libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,17 +55,17 @@ dependencies {
     // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
     // Also check Jetpack libraries update to go along with it: https://developer.android.com/jetpack/androidx/versions/all-channel
 
-    def compose_ui_version = "1.6.0-alpha04"
-    def nav_version = "2.7.1"
+    def compose_ui_version = "1.6.0-alpha07"
+    def nav_version = "2.7.4"
     def hilt_version = "2.47"
     def androidx_hilt_version = "1.0.0"
-    def gson_version = "2.9.0"
-    def room_version = "2.6.0-beta01"
+    def gson_version = "2.9.1"
+    def room_version = "2.6.0-rc01"
     def okhttp_version = "4.10.0"
-    def core_version = "1.12.0-rc01"
+    def core_version = "1.12.0"
     def material3_version = "1.2.0-alpha06"
-    def lifecycle_version = "2.7.0-alpha01"
-    def activity_version = "1.8.0-alpha07"
+    def lifecycle_version = "2.7.0-alpha02"
+    def activity_version = "1.8.0"
     def firebase_version = "32.3.1"
     def accompanist_permissions_version = "0.33.2-alpha"
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
+    id 'com.android.application' version '8.1.2' apply false
+    id 'com.android.library' version '8.1.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
     id "org.jlleitschuh.gradle.ktlint" version "10.3.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 26 01:31:38 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump AGP to 8.1.2
Bump Gradle to 8.2
Bump compose-ui to 1.6.0-alpha07
Bump navigation to 2.7.4
Bump gson to 2.9.1
Bump room to 2.6.0-rc01
Bump core to 1.12.0
Bump lifecycle to 2.7.0-alpha02
Bump activity to 1.8.0
