### PR TITLE
Bump dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,18 +61,18 @@ dependencies {
     // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
     // Also check Jetpack libraries update to go along with it: https://developer.android.com/jetpack/androidx/versions/all-channel
 
-    def compose_ui_version = "1.6.0-alpha07"
-    def nav_version = "2.7.4"
+    def compose_ui_version = "1.6.0-alpha08"
+    def nav_version = "2.7.5"
     def hilt_version = "2.47"
-    def androidx_hilt_version = "1.0.0"
-    def gson_version = "2.9.1"
-    def room_version = "2.6.0-rc01"
+    def androidx_hilt_version = "1.1.0"
+    def gson_version = "2.10"
+    def room_version = "2.6.0"
     def okhttp_version = "4.10.0"
     def core_version = "1.12.0"
-    def material3_version = "1.2.0-alpha06"
-    def lifecycle_version = "2.7.0-alpha02"
+    def material3_version = "1.2.0-alpha10"
+    def lifecycle_version = "2.7.0-beta01"
     def activity_version = "1.8.0"
-    def firebase_version = "32.3.1"
+    def firebase_version = "32.5.0"
     def accompanist_permissions_version = "0.33.2-alpha"
 
     implementation "androidx.core:core-ktx:$core_version"

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/medicationdetail/MedicationDetailRoute.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/medicationdetail/MedicationDetailRoute.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonColors
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -98,10 +100,12 @@ fun MedicationDetailScreen(
                 SingleChoiceSegmentedButtonRow(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(56.dp),
+                        .height(56.dp)
                 ) {
                     SegmentedButton(
+                        modifier = Modifier.padding(horizontal = 8.dp),
                         selected = isTakenTapped,
+                        shape = MaterialTheme.shapes.extraLarge,
                         onClick = {
                             isTakenTapped = !isTakenTapped
                             if (isTakenTapped) {
@@ -117,7 +121,9 @@ fun MedicationDetailScreen(
                         )
                     }
                     SegmentedButton(
+                        modifier = Modifier.padding(horizontal = 8.dp),
                         selected = isSkippedTapped,
+                        shape = MaterialTheme.shapes.extraLarge,
                         onClick = {
                             isSkippedTapped = !isSkippedTapped
                             if (isSkippedTapped) {

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/medicationdetail/MedicationDetailRoute.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/medicationdetail/MedicationDetailRoute.kt
@@ -20,8 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonColors
-import androidx.compose.material3.Shapes
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         // Before updating, check Kotlin compatibility with Compose Compiler: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility
         // Also check Jetpack libraries update to go along with it: https://developer.android.com/jetpack/androidx/versions/all-channel
-        compose_compiler_version = '1.5.2'
-        compose_version = '1.3.3'
+        compose_compiler_version = '1.5.4'
+        compose_version = '1.5.4'
         hilt_version = '2.47'
         ktlint_version = '10.3.0'
         google_services_version = '4.3.13'
@@ -25,7 +25,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.1.2' apply false
     id 'com.android.library' version '8.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
     id "org.jlleitschuh.gradle.ktlint" version "10.3.0"
 }
 


### PR DESCRIPTION
Bump compose-compiler to 1.5.4
Bump compose-foundation to 1.5.4
Bump compose-ui to 1.6.0-alpha08
Bump navigation to 2.7.5
Bump hilt to 1.1.0
Bump gson to 2.10
Bump room to 2.6.0
Bump compose-material3 to 1.2.0-alpha10
Bump lifecycle to 2.7.0-beta01
Bump firebase to 32.5.0