### PR TITLE
Removed all Date and Calendar instances replaces with LocalDate and LocalTime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -66,6 +67,8 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.compose.navigation)
     implementation(libs.compose.fundation)
+    // de-sugaring to use Java8 features
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(libs.compose.preview)
 

--- a/app/src/main/java/com/waseefakhtar/doseapp/MedicationNotificationService.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/MedicationNotificationService.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.waseefakhtar.doseapp.analytics.AnalyticsHelper
 import com.waseefakhtar.doseapp.domain.model.Medication
+import com.waseefakhtar.doseapp.extension.millisSinceEpoch
 
 class MedicationNotificationService(
     private val context: Context
@@ -26,7 +27,7 @@ class MedicationNotificationService(
         )
 
         val alarmService = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val time = medication.medicationTime.time
+        val time = medication.medicationTime.millisSinceEpoch
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             try {

--- a/app/src/main/java/com/waseefakhtar/doseapp/analytics/AnalyticsHelper.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/analytics/AnalyticsHelper.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.waseefakhtar.doseapp.domain.model.Medication
 import com.waseefakhtar.doseapp.extension.toFormattedDateString
-import java.util.Date
+import java.time.LocalDateTime
 
 class AnalyticsHelper private constructor(context: Context) {
 
@@ -30,7 +30,7 @@ class AnalyticsHelper private constructor(context: Context) {
         val params = Bundle()
         params.putString("medication_time", medication.medicationTime.toFormattedDateString())
         params.putString("medication_end_date", medication.endDate.toFormattedDateString())
-        params.putString("notification_time", Date().toFormattedDateString())
+        params.putString("notification_time", LocalDateTime.now().toFormattedDateString())
         logEvent(AnalyticsEvents.MEDICATION_NOTIFICATION_SHOWN, params)
     }
 
@@ -38,7 +38,7 @@ class AnalyticsHelper private constructor(context: Context) {
         val params = Bundle()
         params.putString("medication_time", medication.medicationTime.toFormattedDateString())
         params.putString("medication_end_date", medication.endDate.toFormattedDateString())
-        params.putString("notification_time", Date().toFormattedDateString())
+        params.putString("notification_time", LocalDateTime.now().toFormattedDateString())
         logEvent(AnalyticsEvents.MEDICATION_NOTIFICATION_SCHEDULED, params)
     }
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/data/Converters.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/data/Converters.kt
@@ -1,16 +1,25 @@
 package com.waseefakhtar.doseapp.data
 
 import androidx.room.TypeConverter
-import java.util.Date
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class Converters {
+
+    private val zoneId = ZoneId.systemDefault()
+
     @TypeConverter
-    fun fromTimestamp(value: Long?): Date? {
-        return value?.let { Date(it) }
+    fun fromTimestamp(value: Long): LocalDateTime {
+        return Instant.ofEpochMilli(value)
+            .atZone(zoneId)
+            .toLocalDateTime()
     }
 
     @TypeConverter
-    fun dateToTimestamp(date: Date?): Long? {
-        return date?.time
+    fun dateToTimestamp(date: LocalDateTime): Long {
+        return date.atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
     }
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/data/MedicationDao.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/data/MedicationDao.kt
@@ -8,7 +8,7 @@ import androidx.room.Query
 import androidx.room.Update
 import com.waseefakhtar.doseapp.data.entity.MedicationEntity
 import kotlinx.coroutines.flow.Flow
-import java.util.Date
+import java.time.LocalDateTime
 
 @Dao
 interface MedicationDao {
@@ -37,5 +37,5 @@ interface MedicationDao {
             WHERE endDate > :date
         """
     )
-    fun getMedicationsForDate(date: Date): Flow<List<MedicationEntity>>
+    fun getMedicationsForDate(date: LocalDateTime): Flow<List<MedicationEntity>>
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/data/entity/MedicationEntity.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/data/entity/MedicationEntity.kt
@@ -2,15 +2,16 @@ package com.waseefakhtar.doseapp.data.entity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.Date
+import java.time.LocalDateTime
 
 @Entity
 data class MedicationEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
     val name: String,
     val dosage: Int,
     val recurrence: String,
-    val endDate: Date,
-    val medicationTime: Date = Date(),
+    val endDate: LocalDateTime,
+    val medicationTime: LocalDateTime = LocalDateTime.now(),
     val medicationTaken: Boolean,
 )

--- a/app/src/main/java/com/waseefakhtar/doseapp/data/mapper/MedicationMapper.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/data/mapper/MedicationMapper.kt
@@ -2,6 +2,7 @@ package com.waseefakhtar.doseapp.data.mapper
 
 import com.waseefakhtar.doseapp.data.entity.MedicationEntity
 import com.waseefakhtar.doseapp.domain.model.Medication
+import java.time.LocalTime
 
 fun MedicationEntity.toMedication(): Medication {
     return Medication(
@@ -9,7 +10,7 @@ fun MedicationEntity.toMedication(): Medication {
         name = name,
         dosage = dosage,
         recurrence = recurrence,
-        endDate = endDate,
+        endDate = endDate.toLocalDate(),
         medicationTime = medicationTime,
         medicationTaken = medicationTaken
     )
@@ -21,7 +22,7 @@ fun Medication.toMedicationEntity(): MedicationEntity {
         name = name,
         dosage = dosage,
         recurrence = recurrence,
-        endDate = endDate,
+        endDate = endDate.atTime(LocalTime.MIN),
         medicationTime = medicationTime,
         medicationTaken = medicationTaken
     )

--- a/app/src/main/java/com/waseefakhtar/doseapp/data/repository/MedicationRepositoryImpl.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/data/repository/MedicationRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.waseefakhtar.doseapp.domain.model.Medication
 import com.waseefakhtar.doseapp.domain.repository.MedicationRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import java.util.Date
+import java.time.LocalDateTime
 
 class MedicationRepositoryImpl(
     private val dao: MedicationDao
@@ -33,7 +33,7 @@ class MedicationRepositoryImpl(
         }
     }
 
-    override fun getMedicationsForDate(date: Date): Flow<List<Medication>> {
+    override fun getMedicationsForDate(date: LocalDateTime): Flow<List<Medication>> {
         return dao.getMedicationsForDate(
             date = date
         ).map { entities ->

--- a/app/src/main/java/com/waseefakhtar/doseapp/domain/model/Medication.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/domain/model/Medication.kt
@@ -2,7 +2,8 @@ package com.waseefakhtar.doseapp.domain.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import java.util.Date
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Parcelize
 data class Medication(
@@ -10,7 +11,7 @@ data class Medication(
     val name: String,
     val dosage: Int,
     val recurrence: String,
-    val endDate: Date,
+    val endDate: LocalDate,
     val medicationTaken: Boolean,
-    val medicationTime: Date
+    val medicationTime: LocalDateTime,
 ) : Parcelable

--- a/app/src/main/java/com/waseefakhtar/doseapp/domain/repository/MedicationRepository.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/domain/repository/MedicationRepository.kt
@@ -2,7 +2,7 @@ package com.waseefakhtar.doseapp.domain.repository
 
 import com.waseefakhtar.doseapp.domain.model.Medication
 import kotlinx.coroutines.flow.Flow
-import java.util.Date
+import java.time.LocalDateTime
 
 interface MedicationRepository {
 
@@ -14,5 +14,5 @@ interface MedicationRepository {
 
     fun getAllMedications(): Flow<List<Medication>>
 
-    fun getMedicationsForDate(date: Date): Flow<List<Medication>>
+    fun getMedicationsForDate(date: LocalDateTime): Flow<List<Medication>>
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/extension/DateExtension.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/extension/DateExtension.kt
@@ -1,38 +1,94 @@
 package com.waseefakhtar.doseapp.extension
 
 import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-fun Date.toFormattedDateString(): String {
-    val sdf = SimpleDateFormat("EEEE, LLLL dd", Locale.getDefault())
+fun LocalDateTime.toFormattedDateString(): String {
+    val sdf = DateTimeFormatter.ofPattern("EEEE, MMMM dd", Locale.getDefault())
     return sdf.format(this)
 }
 
-fun Date.toFormattedMonthDateString(): String {
-    val sdf = SimpleDateFormat("MMMM dd", Locale.getDefault())
+fun LocalDate.toFormattedDateString(): String {
+    val sdf = DateTimeFormatter.ofPattern("EEEE, MMMM dd", Locale.getDefault())
     return sdf.format(this)
 }
 
-fun Date.toFormattedDateShortString(): String {
-    val sdf = SimpleDateFormat("dd", Locale.getDefault())
+/**
+ * Formats a [LocalDateTime] object into readable date format of patten `MMMM dd`
+ * Example: December 31
+ */
+fun LocalDateTime.toFormattedMonthDateString(): String {
+    val sdf = DateTimeFormatter.ofPattern("MMMM dd", Locale.getDefault())
     return sdf.format(this)
 }
+
+fun LocalDate.toFormattedMonthDateString(): String {
+    val sdf = DateTimeFormatter.ofPattern("MMMM dd", Locale.getDefault())
+    return sdf.format(this)
+}
+
+
+/**
+ * Formats a [LocalDateTime] object into readable date of format of pattern `dd`
+ * Example: 31
+ */
+fun LocalDateTime.toFormattedDateShortString(): String {
+    val sdf = DateTimeFormatter.ofPattern("dd", Locale.getDefault())
+    return sdf.format(this)
+}
+
+fun LocalDate.toFormattedDateShortString(): String {
+    val sdf = DateTimeFormatter.ofPattern("dd", Locale.getDefault())
+    return sdf.format(this)
+}
+
 
 fun Long.toFormattedDateString(): String {
     val sdf = SimpleDateFormat("LLLL dd, yyyy", Locale.getDefault())
     return sdf.format(this)
 }
 
-fun Date.toFormattedTimeString(): String {
-    val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+
+/**
+ * Formats a [LocalDateTime] object into readable time format of patten `HH:mm`
+ * Example: 12:00
+ */
+fun LocalDateTime.toFormattedTimeString(): String {
+    val timeFormat = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault())
     return timeFormat.format(this)
 }
 
-fun Date.hasPassed(): Boolean {
-    val calendar = Calendar.getInstance()
-    calendar.add(Calendar.SECOND, -1)
-    val oneSecondAgo = calendar.time
-    return time < oneSecondAgo.time
+/**
+ * Formats a [LocalTime] object into readable time format of patten `HH:mm`
+ * Example: 12:00
+ */
+fun LocalTime.toFormattedTimeString(): String {
+    val timeFormat = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault())
+    return timeFormat.format(this)
 }
+
+val LocalDateTime.millisSinceEpoch: Long
+    get() = atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+val LocalDate.millisSinceEpoch: Long
+    get() = atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+
+/**
+ * Checks if the [LocalDateTime] has passed
+ */
+val LocalDateTime.hasPassed: Boolean
+    get() = this < LocalDateTime.now()
+
+
+//fun Date.hasPassed(): Boolean {
+//    val calendar = Calendar.getInstance()
+//    calendar.add(Calendar.SECOND, -1)
+//    val oneSecondAgo = calendar.time
+//    return time < oneSecondAgo.time
+//}

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/StateSavers.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/StateSavers.kt
@@ -1,0 +1,47 @@
+package com.waseefakhtar.doseapp.feature.addmedication
+
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.SaverScope
+import com.waseefakhtar.doseapp.extension.millisSinceEpoch
+import com.waseefakhtar.doseapp.util.Recurrence
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+object StateSavers {
+
+    val localDateSaver = object : Saver<LocalDate, Long> {
+
+        override fun restore(value: Long): LocalDate = Instant.ofEpochMilli(value)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDate()
+
+        override fun SaverScope.save(value: LocalDate): Long = value.millisSinceEpoch
+    }
+
+    val recurrenceSaver = object : Saver<Recurrence, String> {
+
+        override fun restore(value: String): Recurrence = Recurrence.valueOf(value)
+
+        override fun SaverScope.save(value: Recurrence): String = value.name
+    }
+
+    val localTimeSaver = object : Saver<LocalTime, Long> {
+
+        override fun restore(value: Long): LocalTime? = LocalTime.ofSecondOfDay(value)
+
+        override fun SaverScope.save(value: LocalTime): Long = value.toSecondOfDay().toLong()
+
+    }
+
+    val localListTimeSaver = object : Saver<MutableList<LocalTime>, List<Long>> {
+
+        override fun restore(value: List<Long>): MutableList<LocalTime> =
+            value.map(LocalTime::ofSecondOfDay).toMutableList()
+
+        override fun SaverScope.save(value: MutableList<LocalTime>): List<Long> =
+            value.map(LocalTime::toSecondOfDay).map(Int::toLong)
+
+    }
+}

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/TimePickerDialogComponent.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/TimePickerDialogComponent.kt
@@ -1,48 +1,38 @@
 package com.waseefakhtar.doseapp.feature.addmedication
 
 import android.app.TimePickerDialog
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import com.waseefakhtar.doseapp.feature.addmedication.model.CalendarInformation
-import java.util.Calendar
+import java.time.LocalTime
 
 @Composable
 fun TimePickerDialogComponent(
     showDialog: Boolean,
-    selectedDate: CalendarInformation,
-    onSelectedTime: (selectedDate: CalendarInformation) -> Unit
+    selectedTime: LocalTime,
+    onSelectedTime: (LocalTime) -> Unit
 ) {
     val listener = setUpOnTimeSetListener(onSelectedTime)
-    val timePickerDialog = getTimePickerDialog(selectedDate, listener)
+    val timePickerDialog = getTimePickerDialog(selectedTime, listener)
     if (showDialog) {
         timePickerDialog.show()
     }
 }
 
 private fun setUpOnTimeSetListener(
-    onSelectedTime: (selectedDate: CalendarInformation) -> Unit
+    onSelectedTime: (LocalTime) -> Unit
 ): TimePickerDialog.OnTimeSetListener {
-    return TimePickerDialog.OnTimeSetListener { timePicker, hourOfDay, minute ->
-        val newDate = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, hourOfDay)
-            set(Calendar.MINUTE, minute)
-        }
-        onSelectedTime(CalendarInformation(newDate))
+    return TimePickerDialog.OnTimeSetListener { _, hourOfDay, minute ->
+        val time = LocalTime.of(hourOfDay, minute)
+        onSelectedTime(time)
     }
 }
 
 @Composable
 private fun getTimePickerDialog(
-    selectedDate: CalendarInformation,
-    listener: TimePickerDialog.OnTimeSetListener
+    selectedTime: LocalTime,
+    listener: TimePickerDialog.OnTimeSetListener,
+    context: Context = LocalContext.current
 ): TimePickerDialog {
-    val context = LocalContext.current
-    val (hour, minute) = selectedDate.dateInformation
-    return TimePickerDialog(
-        context,
-        listener,
-        hour,
-        minute,
-        false
-    )
+    return TimePickerDialog(context, listener, selectedTime.hour, selectedTime.minute, false)
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/viewmodel/AddMedicationViewModel.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/addmedication/viewmodel/AddMedicationViewModel.kt
@@ -2,61 +2,57 @@ package com.waseefakhtar.doseapp.feature.addmedication.viewmodel
 
 import androidx.lifecycle.ViewModel
 import com.waseefakhtar.doseapp.domain.model.Medication
-import com.waseefakhtar.doseapp.feature.addmedication.model.CalendarInformation
-import java.util.Calendar
-import java.util.Date
+import com.waseefakhtar.doseapp.util.Recurrence
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.Period
 
 class AddMedicationViewModel : ViewModel() {
 
     fun createMedications(
         name: String,
         dosage: Int,
-        recurrence: String,
-        endDate: Date,
-        medicationTimes: List<CalendarInformation>,
-        startDate: Date = Date()
+        recurrence: Recurrence,
+        endDate: LocalDate,
+        medicationTimes: List<LocalTime>,
+        startDate: LocalDate = LocalDate.now()
     ): List<Medication> {
 
         // Determine the recurrence interval based on the selected recurrence
         val interval = when (recurrence) {
-            "Daily" -> 1
-            "Weekly" -> 7
-            "Monthly" -> 30
-            else -> throw IllegalArgumentException("Invalid recurrence: $recurrence")
+            Recurrence.Daily -> 1
+            Recurrence.Weekly -> 7
+            Recurrence.Monthly -> 30
         }
 
-        val oneDayInMillis = 86400 * 1000 // Number of milliseconds in one day
-        val numOccurrences = ((endDate.time + oneDayInMillis - startDate.time) / (interval * oneDayInMillis)).toInt() + 1
+        val daysDifference = Period.between(startDate, endDate).days
+
+        val numOccurrences = daysDifference / interval + 1
 
         // Create a Medication object for each occurrence and add it to a list
         val medications = mutableListOf<Medication>()
-        val calendar = Calendar.getInstance()
-        calendar.time = startDate
-        for (i in 0 until numOccurrences) {
-            for (medicationTime in medicationTimes) {
+        var start = startDate
+        repeat(numOccurrences) {
+            medicationTimes.forEach { time ->
+                val medicationDateTime = LocalDateTime.of(start, time)
                 // TODO: Generate id automatically.
                 val medication = Medication(
                     id = 0,
                     name = name,
                     dosage = dosage,
-                    recurrence = recurrence,
+                    recurrence = recurrence.name,
                     endDate = endDate,
                     medicationTaken = false,
-                    medicationTime = getMedicationTime(medicationTime, calendar)
+                    medicationTime = medicationDateTime
                 )
                 medications.add(medication)
             }
-
             // Increment the date based on the recurrence interval
-            calendar.add(Calendar.DAY_OF_YEAR, interval)
+            start = start.plusDays(interval.toLong())
         }
 
         return medications
     }
 
-    private fun getMedicationTime(medicationTime: CalendarInformation, calendar: Calendar): Date {
-        calendar.set(Calendar.HOUR_OF_DAY, medicationTime.dateInformation.hour)
-        calendar.set(Calendar.MINUTE, medicationTime.dateInformation.minute)
-        return calendar.time
-    }
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/calendar/viewmodel/CalendarState.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/calendar/viewmodel/CalendarState.kt
@@ -1,8 +1,8 @@
 package com.waseefakhtar.doseapp.feature.calendar.viewmodel
 
-import java.util.Date
+import java.time.LocalDate
 
 // TODO: Fill out when Calendar feature is implemented
 data class CalendarState(
-    val currentDate: Date? = null
+    val currentDate: LocalDate? = null
 )

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/history/HistoryScreen.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/history/HistoryScreen.kt
@@ -72,7 +72,7 @@ fun HistoryScreen(analyticsHelper: AnalyticsHelper, state: HistoryState, navigat
 @Composable
 fun MedicationList(analyticsHelper: AnalyticsHelper, state: HistoryState, navigateToMedicationDetail: (Medication) -> Unit) {
 
-    val filteredMedicationList = state.medications.filter { it.medicationTime.hasPassed() }
+    val filteredMedicationList = state.medications.filter { it.medicationTime.hasPassed }
     val sortedMedicationList: List<MedicationListItem> = filteredMedicationList.sortedBy { it.medicationTime }.map { MedicationListItem.MedicationItem(it) }
 
     when (sortedMedicationList.isEmpty()) {

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/HomeScreen.kt
@@ -20,12 +20,13 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardDefaults.cardColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -62,8 +63,7 @@ import com.waseefakhtar.doseapp.feature.home.data.CalendarDataSource
 import com.waseefakhtar.doseapp.feature.home.model.CalendarModel
 import com.waseefakhtar.doseapp.feature.home.viewmodel.HomeState
 import com.waseefakhtar.doseapp.feature.home.viewmodel.HomeViewModel
-import java.util.Calendar
-import java.util.Date
+import java.time.LocalDate
 
 @Composable
 fun HomeRoute(
@@ -82,11 +82,23 @@ fun HomeRoute(
 }
 
 @Composable
-fun HomeScreen(navController: NavController, analyticsHelper: AnalyticsHelper, state: HomeState, viewModel: HomeViewModel, navigateToMedicationDetail: (Medication) -> Unit) {
+fun HomeScreen(
+    navController: NavController,
+    analyticsHelper: AnalyticsHelper,
+    state: HomeState,
+    viewModel: HomeViewModel,
+    navigateToMedicationDetail: (Medication) -> Unit
+) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        DailyMedications(navController, analyticsHelper, state, viewModel, navigateToMedicationDetail)
+        DailyMedications(
+            navController = navController,
+            analyticsHelper = analyticsHelper,
+            state = state,
+            viewModel = viewModel,
+            navigateToMedicationDetail = navigateToMedicationDetail
+        )
     }
 }
 
@@ -110,7 +122,11 @@ fun Greeting() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DailyOverviewCard(navController: NavController, analyticsHelper: AnalyticsHelper, medicationsToday: List<Medication>) {
+fun DailyOverviewCard(
+    navController: NavController,
+    analyticsHelper: AnalyticsHelper,
+    medicationsToday: List<Medication>
+) {
 
     Card(
         modifier = Modifier
@@ -118,7 +134,7 @@ fun DailyOverviewCard(navController: NavController, analyticsHelper: AnalyticsHe
             .padding(top = 8.dp)
             .height(156.dp),
         shape = RoundedCornerShape(36.dp),
-        colors = cardColors(
+        colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer,
             contentColor = MaterialTheme.colorScheme.tertiary
         ),
@@ -218,7 +234,13 @@ fun EmptyCard(navController: NavController, analyticsHelper: AnalyticsHelper) {
 }
 
 @Composable
-fun DailyMedications(navController: NavController, analyticsHelper: AnalyticsHelper, state: HomeState, viewModel: HomeViewModel, navigateToMedicationDetail: (Medication) -> Unit) {
+fun DailyMedications(
+    navController: NavController,
+    analyticsHelper: AnalyticsHelper,
+    state: HomeState,
+    viewModel: HomeViewModel,
+    navigateToMedicationDetail: (Medication) -> Unit
+) {
 
     var filteredMedications: List<Medication> by remember { mutableStateOf(emptyList()) }
 
@@ -271,25 +293,31 @@ fun DatesHeader(
             onPrevClickListener = { startDate ->
                 // refresh the CalendarModel with new data
                 // by get data with new Start Date (which is the startDate-1 from the visibleDates)
-                val calendar = Calendar.getInstance()
-                calendar.time = startDate
+//                val calendar = Calendar.getInstance()
+//                calendar.time = startDate
+//
+//                calendar.add(Calendar.DAY_OF_YEAR, -2) // Subtract one day from startDate
+//                val finalStartDate = calendar.time
 
-                calendar.add(Calendar.DAY_OF_YEAR, -2) // Subtract one day from startDate
-                val finalStartDate = calendar.time
-
-                calendarModel = dataSource.getData(startDate = finalStartDate, lastSelectedDate = calendarModel.selectedDate.date)
+                calendarModel = dataSource.getData(
+                    startDate = startDate.minusDays(2),
+                    lastSelectedDate = calendarModel.selectedDate.date
+                )
                 analyticsHelper.logEvent(AnalyticsEvents.HOME_CALENDAR_PREVIOUS_WEEK_CLICKED)
             },
             onNextClickListener = { endDate ->
                 // refresh the CalendarModel with new data
                 // by get data with new Start Date (which is the endDate+2 from the visibleDates)
-                val calendar = Calendar.getInstance()
-                calendar.time = endDate
+//                val calendar = Calendar.getInstance()
+//                calendar.time = endDate
+//
+//                calendar.add(Calendar.DAY_OF_YEAR, 2)
+//                val finalStartDate = calendar.time
 
-                calendar.add(Calendar.DAY_OF_YEAR, 2)
-                val finalStartDate = calendar.time
-
-                calendarModel = dataSource.getData(startDate = finalStartDate, lastSelectedDate = calendarModel.selectedDate.date)
+                calendarModel = dataSource.getData(
+                    startDate = endDate.plusDays(2),
+                    lastSelectedDate = calendarModel.selectedDate.date
+                )
                 analyticsHelper.logEvent(AnalyticsEvents.HOME_CALENDAR_NEXT_WEEK_CLICKED)
             }
         )
@@ -379,8 +407,8 @@ fun DateItem(
 @Composable
 fun DateHeader(
     data: CalendarModel,
-    onPrevClickListener: (Date) -> Unit,
-    onNextClickListener: (Date) -> Unit
+    onPrevClickListener: (LocalDate) -> Unit,
+    onNextClickListener: (LocalDate) -> Unit
 ) {
     Row(
         modifier = Modifier.padding(vertical = 16.dp),
@@ -398,20 +426,24 @@ fun DateHeader(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.tertiary
         )
-        IconButton(onClick = {
-            onPrevClickListener(data.startDate.date)
-        }) {
+        IconButton(
+            onClick = {
+                onPrevClickListener(data.startDate.date)
+            },
+        ) {
             Icon(
-                imageVector = Icons.Filled.KeyboardArrowLeft,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                 tint = MaterialTheme.colorScheme.tertiary,
                 contentDescription = "Back"
             )
         }
-        IconButton(onClick = {
-            onNextClickListener(data.endDate.date)
-        }) {
+        IconButton(
+            onClick = {
+                onNextClickListener(data.endDate.date)
+            },
+        ) {
             Icon(
-                imageVector = Icons.Filled.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 tint = MaterialTheme.colorScheme.tertiary,
                 contentDescription = "Next"
             )
@@ -420,21 +452,29 @@ fun DateHeader(
 }
 
 sealed class MedicationListItem {
-    data class OverviewItem(val medicationsToday: List<Medication>, val isMedicationListEmpty: Boolean) : MedicationListItem()
+    data class OverviewItem(
+        val medicationsToday: List<Medication>,
+        val isMedicationListEmpty: Boolean
+    ) : MedicationListItem()
+
     data class MedicationItem(val medication: Medication) : MedicationListItem()
     data class HeaderItem(val headerText: String) : MedicationListItem()
 }
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun PermissionDialog(analyticsHelper: AnalyticsHelper, askNotificationPermission: Boolean) {
+fun PermissionDialog(
+    analyticsHelper: AnalyticsHelper,
+    askNotificationPermission: Boolean,
+) {
     if (askNotificationPermission && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)) {
-        val notificationPermissionState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS) { isGranted ->
-            when (isGranted) {
-                true -> analyticsHelper.logEvent(AnalyticsEvents.NOTIFICATION_PERMISSION_GRANTED)
-                false -> analyticsHelper.logEvent(AnalyticsEvents.NOTIFICATION_PERMISSION_REFUSED)
+        val notificationPermissionState =
+            rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS) { isGranted ->
+                when (isGranted) {
+                    true -> analyticsHelper.logEvent(AnalyticsEvents.NOTIFICATION_PERMISSION_GRANTED)
+                    false -> analyticsHelper.logEvent(AnalyticsEvents.NOTIFICATION_PERMISSION_REFUSED)
+                }
             }
-        }
         if (!notificationPermissionState.status.isGranted) {
             val openAlertDialog = remember { mutableStateOf(true) }
 
@@ -482,12 +522,13 @@ fun PermissionAlarmDialog(analyticsHelper: AnalyticsHelper, askAlarmPermission: 
     val context = LocalContext.current
     val alarmManager = ContextCompat.getSystemService(context, AlarmManager::class.java)
     if (askAlarmPermission && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
-        val alarmPermissionState = rememberPermissionState(Manifest.permission.SCHEDULE_EXACT_ALARM) { isGranted ->
-            when (isGranted) {
-                true -> analyticsHelper.logEvent(AnalyticsEvents.ALARM_PERMISSION_GRANTED)
-                false -> analyticsHelper.logEvent(AnalyticsEvents.ALARM_PERMISSION_REFUSED)
+        val alarmPermissionState =
+            rememberPermissionState(Manifest.permission.SCHEDULE_EXACT_ALARM) { isGranted ->
+                when (isGranted) {
+                    true -> analyticsHelper.logEvent(AnalyticsEvents.ALARM_PERMISSION_GRANTED)
+                    false -> analyticsHelper.logEvent(AnalyticsEvents.ALARM_PERMISSION_REFUSED)
+                }
             }
-        }
         if (alarmManager?.canScheduleExactAlarms() == false) {
             val openAlertDialog = remember { mutableStateOf(true) }
 

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/MedicationCard.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/MedicationCard.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,7 +25,8 @@ import com.waseefakhtar.doseapp.domain.model.Medication
 import com.waseefakhtar.doseapp.extension.hasPassed
 import com.waseefakhtar.doseapp.extension.toFormattedDateString
 import com.waseefakhtar.doseapp.extension.toFormattedTimeString
-import java.util.Date
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,7 +34,6 @@ fun MedicationCard(
     medication: Medication,
     navigateToMedicationDetail: (Medication) -> Unit
 ) {
-
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -69,7 +69,7 @@ fun MedicationCard(
                 )
 
                 val medicationStatusText = when {
-                    medication.medicationTime.hasPassed() -> {
+                    medication.medicationTime.hasPassed -> {
                         if (medication.medicationTaken) {
                             stringResource(
                                 id = R.string.medication_taken_at,
@@ -95,7 +95,10 @@ fun MedicationCard(
                 )
             }
 
-            Icon(imageVector = Icons.Default.KeyboardArrowRight, contentDescription = null)
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null
+            )
         }
     }
 }
@@ -109,11 +112,12 @@ private fun MedicationCardTakeNowPreview() {
             name = "A big big name for a little medication I needs to take",
             dosage = 1,
             recurrence = "2",
-            endDate = Date(),
-            medicationTime = Date(),
+            endDate = LocalDate.now(),
+            medicationTime = LocalDateTime.now(),
             medicationTaken = false
-        )
-    ) { }
+        ),
+        navigateToMedicationDetail = {}
+    )
 }
 
 @Preview
@@ -125,9 +129,9 @@ private fun MedicationCardTakenPreview() {
             name = "A big big name for a little medication I needs to take",
             dosage = 1,
             recurrence = "2",
-            endDate = Date(),
-            medicationTime = Date(),
-            medicationTaken = true
-        )
-    ) { }
+            endDate = LocalDate.now(),
+            medicationTime = LocalDateTime.now(),
+            medicationTaken = false
+        ),
+        navigateToMedicationDetail = {})
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/data/CalendarDataSource.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/data/CalendarDataSource.kt
@@ -1,65 +1,50 @@
 package com.waseefakhtar.doseapp.feature.home.data
 
-import com.waseefakhtar.doseapp.extension.toFormattedDateString
 import com.waseefakhtar.doseapp.feature.home.model.CalendarModel
-import java.util.Calendar
-import java.util.Date
+import java.time.LocalDate
 
 class CalendarDataSource {
 
-    val today: Date
-        get() {
-            return Date()
-        }
+    val today: LocalDate
+        get() = LocalDate.now()
 
-    fun getData(startDate: Date = today, lastSelectedDate: Date): CalendarModel {
-        val calendar = Calendar.getInstance()
-        calendar.time = startDate
+    fun getData(startDate: LocalDate = today, lastSelectedDate: LocalDate): CalendarModel {
+        val weekDayStart = startDate.dayOfWeek.value - 1L
 
-        calendar.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
-        val firstDayOfWeek = calendar.time
+        val firstDayOfWeek = startDate.minusDays(weekDayStart)
 
-        calendar.add(Calendar.DAY_OF_YEAR, 6)
-        val endDayOfWeek = calendar.time
+        val endDayOfWeek = startDate.plusDays(6L - weekDayStart)
 
         val visibleDates = getDatesBetween(firstDayOfWeek, endDayOfWeek)
         return toCalendarModel(visibleDates, lastSelectedDate)
     }
 
-    private fun getDatesBetween(startDate: Date, endDate: Date): List<Date> {
-        val dateList = mutableListOf<Date>()
-        val calendar = Calendar.getInstance()
-        calendar.time = startDate
-
-        while (calendar.time <= endDate) {
-            dateList.add(calendar.time)
-            calendar.add(Calendar.DAY_OF_YEAR, 1)
+    private fun getDatesBetween(startDate: LocalDate, endDate: LocalDate): List<LocalDate> =
+        buildList {
+            var start = startDate
+            while (start <= endDate) {
+                add(start)
+                start = start.plusDays(1)
+            }
         }
-        return dateList
-    }
 
     private fun toCalendarModel(
-        dateList: List<Date>,
-        lastSelectedDate: Date
-    ): CalendarModel {
-        return CalendarModel(
-            selectedDate = toItemModel(lastSelectedDate, true),
-            visibleDates = dateList.map {
-                toItemModel(it, it == lastSelectedDate)
-            }
-        )
-    }
+        dateList: List<LocalDate>,
+        lastSelectedDate: LocalDate
+    ): CalendarModel = CalendarModel(
+        selectedDate = toItemModel(lastSelectedDate, true),
+        visibleDates = dateList.map {
+            toItemModel(it, it == lastSelectedDate)
+        }
+    )
 
-    private fun toItemModel(date: Date, isSelectedDate: Boolean): CalendarModel.DateModel {
+
+    private fun toItemModel(date: LocalDate, isSelectedDate: Boolean): CalendarModel.DateModel {
         return CalendarModel.DateModel(
             isSelected = isSelectedDate,
-            isToday = isToday(date),
+            isToday = today == date,
             date = date
         )
     }
 
-    private fun isToday(date: Date): Boolean {
-        val todayDate = today
-        return date.toFormattedDateString() == todayDate.toFormattedDateString()
-    }
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/model/CalendarModel.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/model/CalendarModel.kt
@@ -1,7 +1,7 @@
 package com.waseefakhtar.doseapp.feature.home.model
 
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 data class CalendarModel(
@@ -13,10 +13,13 @@ data class CalendarModel(
     val endDate: DateModel = visibleDates.last() // the last of the visible dates
 
     data class DateModel(
-        val date: Date,
+        val date: LocalDate,
         val isSelected: Boolean,
         val isToday: Boolean
     ) {
-        val day: String = SimpleDateFormat("E", Locale.getDefault()).format(date) ?: ""
+        val day: String
+            get() = DateTimeFormatter
+                .ofPattern("E", Locale.getDefault())
+                .format(date) ?: ""
     }
 }

--- a/app/src/main/java/com/waseefakhtar/doseapp/util/RecurrenceUtil.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/util/RecurrenceUtil.kt
@@ -5,12 +5,3 @@ enum class Recurrence {
     Weekly,
     Monthly
 }
-
-fun getRecurrenceList(): List<Recurrence> {
-    val recurrenceList = mutableListOf<Recurrence>()
-    recurrenceList.add(Recurrence.Daily)
-    recurrenceList.add(Recurrence.Weekly)
-    recurrenceList.add(Recurrence.Monthly)
-
-    return recurrenceList
-}

--- a/app/src/main/java/com/waseefakhtar/doseapp/util/TimeUtils.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/util/TimeUtils.kt
@@ -1,33 +1,60 @@
 package com.waseefakhtar.doseapp.util
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import com.waseefakhtar.doseapp.R
 import com.waseefakhtar.doseapp.domain.model.Medication
 import com.waseefakhtar.doseapp.extension.toFormattedDateString
-import java.util.Calendar
-import java.util.concurrent.TimeUnit
-import kotlin.math.abs
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
 
 const val HOUR_MINUTE_FORMAT = "h:mm a"
+
 @Composable
-fun getTimeRemaining(medication: Medication): String {
-    val currentTime = Calendar.getInstance().time
-    val dateBefore = medication.medicationTime
-    val timeDiff = abs(currentTime.time - dateBefore.time)
+fun getTimeRemaining(
+    medication: Medication,
+    time: LocalDateTime = LocalDateTime.now()
+): String {
+
+    val timeDiff by remember {
+        derivedStateOf {
+            val medicationTime = medication.medicationTime
+            val between = ChronoUnit.MILLIS.between(time, medicationTime)
+            between.milliseconds
+        }
+    }
 
     // If the medication is scheduled for a future date, display days remaining
     if (medication.medicationTime.toFormattedDateString() != medication.endDate.toFormattedDateString()) {
-        val daysRemaining = TimeUnit.DAYS.convert(timeDiff, TimeUnit.MILLISECONDS) + 1L
-        return stringResource(id = R.string.time_remaining, daysRemaining, stringResource(id = R.string.days))
+        val daysRemaining = timeDiff.toDouble(DurationUnit.DAYS) + 1L
+        return stringResource(
+            id = R.string.time_remaining,
+            daysRemaining,
+            stringResource(id = R.string.days)
+        )
     }
 
     // If the medication is scheduled for today, calculate time remaining in hours and minutes
-    val hoursRemaining = TimeUnit.HOURS.convert(timeDiff, TimeUnit.MILLISECONDS)
-    val minutesRemaining = TimeUnit.MINUTES.convert(timeDiff, TimeUnit.MILLISECONDS)
+    val hoursRemaining = timeDiff.toDouble(DurationUnit.HOURS)
+    val minutesRemaining = timeDiff.toDouble(DurationUnit.MINUTES)
     return when {
-        hoursRemaining > 1 -> stringResource(id = R.string.time_remaining, hoursRemaining, stringResource(id = R.string.hours))
-        minutesRemaining > 1 -> stringResource(id = R.string.time_remaining, minutesRemaining, stringResource(id = R.string.days))
+        hoursRemaining > 1 -> stringResource(
+            id = R.string.time_remaining,
+            hoursRemaining,
+            stringResource(id = R.string.hours)
+        )
+
+        minutesRemaining > 1 -> stringResource(
+            id = R.string.time_remaining,
+            minutesRemaining,
+            stringResource(id = R.string.days)
+        )
+
         else -> stringResource(id = R.string.take_dose_now)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+desugar_jdk_libs = "2.0.4"
 min-sdk-version = "21"
 compile-sdk-version = "34"
 target-sdk-version = "34"
@@ -44,6 +45,7 @@ compose-ui-tooling-debug = { group="androidx.compose.ui", name="ui-tooling", ver
 compose-ui-test-manifest = { group="androidx.compose.ui", name="ui-test-manifest", version.ref="compose" }
 compose-ui = { group="androidx.compose.ui", name="ui", version.ref="compose" }
 # Firebase
+desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 firebase-analytics = { group="com.google.firebase", name="firebase-analytics" }
 firebase-crashlytics = { group="com.google.firebase", name="firebase-crashlytics" }
 firebase-bom = { group="com.google.firebase", name="firebase-bom", version.ref="firebase" }


### PR DESCRIPTION
This pull request contains the following changes addressing #144 ,
If you have any questions please let me know.

Migration from LocalDate to LocalTime and less use of Calendar instance
Removed all the Date Instances with LocalDate / LocalTime As with Dates it need to used with Calendar Api in most of the cases , LocalDate and others have direct methods for adding hours/ days ... etc. Thus removed most of Calendar Instances.