### PR TITLE
Fix - Don't Show Today medications List until user clicks the today date chip

### DIFF
--- a/app/src/main/java/com/waseefakhtar/doseapp/feature/home/usecase/GetMedicationsUseCase.kt
+++ b/app/src/main/java/com/waseefakhtar/doseapp/feature/home/usecase/GetMedicationsUseCase.kt
@@ -9,7 +9,7 @@ class GetMedicationsUseCase @Inject constructor(
     private val repository: MedicationRepository
 ) {
 
-    suspend fun getMedications(): Flow<List<Medication>> {
+     fun getMedications(): Flow<List<Medication>> {
         return repository.getAllMedications()
     }
 }


### PR DESCRIPTION
When a user creates the today medications but the app doesn't show the today medications List in Home Screen until the user clicks the today date chip. Until the user clicks the chip , No medications Scheduled for this date is shown.It can make the user confused.

So I fix above issue
After fixing , user can see today medications list without clicking the today date chip.

Closes #150 
